### PR TITLE
Add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ Try it out: https://op-explorer.pauldowman.com/
 
 I'm hiring engineering roles for the Proofs team at OP Labs. Take a look at [our open roles](https://jobs.ashbyhq.com/oplabs), apply, and [get in touch with me](https://www.pauldowman.com/) if you have questions or to let me know you've applied.
 
+## Running tests
+
+1. Install dependencies with `npm install`.
+2. Run the tests using `npm test`. This executes the Vitest suite in a jsdom environment.
+   You can also run `npx vitest watch` to watch for changes during development.
+
 
  # To do
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^18.3.1",
@@ -27,6 +28,10 @@
     "globals": "^15.9.0",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^6.2.6"
+    "vite": "^6.2.6",
+    "vitest": "^1.4.0",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.1.4",
+    "jsdom": "^23.0.0"
   }
 }

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { getGameTypeName } from '../config';
+
+describe('getGameTypeName', () => {
+  it('returns name for known type', () => {
+    expect(getGameTypeName(0)).toBe('Cannon');
+    expect(getGameTypeName(1)).toBe('Permissioned Cannon');
+  });
+
+  it('returns UNKNOWN for unknown type', () => {
+    expect(getGameTypeName(999)).toBe('UNKNOWN');
+  });
+});

--- a/src/components/__tests__/DisplayAddress.test.tsx
+++ b/src/components/__tests__/DisplayAddress.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import DisplayAddress from '../DisplayAddress';
+
+const address = '0x1234567890abcdef1234567890abcdef12345678' as const;
+
+it('renders truncated address and link', () => {
+  render(<DisplayAddress address={address} blockExplorerURL="https://etherscan.io" />);
+  // truncated address should appear
+  const truncated = '0x12345678...12345678';
+  expect(screen.getByText(truncated)).toBeInTheDocument();
+  const link = screen.getByRole('link');
+  expect(link).toHaveAttribute('href', `https://etherscan.io/address/${address}`);
+});

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: './src/setupTests.ts',
+  },
+});


### PR DESCRIPTION
## Summary
- document how to run the Vitest suite in the README

## Testing
- `npm test` *(fails: vitest not found)*