### PR TITLE
Withdrawal page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import L1Info from './components/L1Info';
 import L2Info from './components/L2Info';
 import DisputeGamesPage from './pages/DisputeGamesPage';
 import DisputeGamePage from './pages/DisputeGamePage';
+import WithdrawalsPage from './pages/WithdrawalsPage';
 import Settings from './components/Settings';
 import Footer from './components/Footer';
 import { CHAIN_CONFIG, ChainName } from './config';
@@ -167,6 +168,7 @@ function App() {
             <ul>
               <li><Link to="/">Home</Link></li>
               <li><Link to="/dispute-games">Dispute Games</Link></li>
+              <li><Link to="/withdrawals">Withdrawals</Link></li>
             </ul>
           </nav>
           
@@ -192,9 +194,17 @@ function App() {
             } />
             <Route path="/dispute-game/:address" element={
               <div className="card">
-                <DisputeGamePage 
-                  publicClientL1={publicClientL1} 
+                <DisputeGamePage
+                  publicClientL1={publicClientL1}
                   chainConfig={chainConfig}
+                />
+              </div>
+            } />
+            <Route path="/withdrawals" element={
+              <div className="card">
+                <WithdrawalsPage
+                  publicClientL2={publicClientL2}
+                  explorerURL={superchainRegistryInfo?.explorer}
                 />
               </div>
             } />

--- a/src/abi/L2ToL1MessagePasser.json
+++ b/src/abi/L2ToL1MessagePasser.json
@@ -1,0 +1,16 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {"indexed": true, "internalType": "uint256", "name": "nonce", "type": "uint256"},
+      {"indexed": true, "internalType": "address", "name": "sender", "type": "address"},
+      {"indexed": true, "internalType": "address", "name": "target", "type": "address"},
+      {"indexed": false, "internalType": "uint256", "name": "value", "type": "uint256"},
+      {"indexed": false, "internalType": "uint256", "name": "gasLimit", "type": "uint256"},
+      {"indexed": false, "internalType": "bytes", "name": "data", "type": "bytes"},
+      {"indexed": false, "internalType": "bytes32", "name": "withdrawalHash", "type": "bytes32"}
+    ],
+    "name": "MessagePassed",
+    "type": "event"
+  }
+]

--- a/src/abi/OptimismPortal.json
+++ b/src/abi/OptimismPortal.json
@@ -1,0 +1,11 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {"indexed": true, "internalType": "bytes32", "name": "withdrawalHash", "type": "bytes32"},
+      {"indexed": false, "internalType": "bool", "name": "success", "type": "bool"}
+    ],
+    "name": "WithdrawalFinalized",
+    "type": "event"
+  }
+]

--- a/src/components/Withdrawals.test.ts
+++ b/src/components/Withdrawals.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { parseMessagePassedLog, MESSAGE_PASSED_EVENT } from './Withdrawals'
+
+const sampleLog = {
+  args: {
+    nonce: 1n,
+    sender: '0x0000000000000000000000000000000000000001',
+    target: '0x0000000000000000000000000000000000000002',
+    value: 3n,
+    gasLimit: 4n,
+    data: '0x',
+    withdrawalHash: '0x1234' as const,
+  },
+  blockNumber: 10n,
+}
+
+describe('parseMessagePassedLog', () => {
+  it('parses log into Withdrawal', () => {
+    const w = parseMessagePassedLog(sampleLog as any)
+    expect(w.nonce).toBe(1n)
+    expect(w.sender).toBe(sampleLog.args.sender)
+    expect(w.target).toBe(sampleLog.args.target)
+    expect(w.value).toBe(3n)
+    expect(w.gasLimit).toBe(4n)
+    expect(w.data).toBe('0x')
+    expect(w.withdrawalHash).toBe('0x1234')
+    expect(w.blockNumber).toBe(10n)
+  })
+})
+
+describe('MESSAGE_PASSED_EVENT', () => {
+  it('is the MessagePassed event definition', () => {
+    expect(MESSAGE_PASSED_EVENT.name).toBe('MessagePassed')
+  })
+})

--- a/src/components/Withdrawals.tsx
+++ b/src/components/Withdrawals.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState } from 'react'
+import type { PublicClient, Address, AbiEvent } from 'viem'
+import { parseAbiItem } from 'viem'
+import { L2_CONTRACTS } from '../config'
+import DisplayAddress from './DisplayAddress'
+
+export const MESSAGE_PASSED_EVENT: AbiEvent = parseAbiItem(
+  'event MessagePassed(uint256 indexed nonce, address indexed sender, address indexed target, uint256 value, uint256 gasLimit, bytes data, bytes32 withdrawalHash)'
+)
+
+export type Withdrawal = {
+  nonce: bigint
+  sender: Address
+  target: Address
+  value: bigint
+  gasLimit: bigint
+  data: `0x${string}`
+  withdrawalHash: `0x${string}`
+  blockNumber: bigint
+}
+
+export function parseMessagePassedLog(log: any): Withdrawal {
+  return {
+    nonce: log.args.nonce,
+    sender: log.args.sender,
+    target: log.args.target,
+    value: log.args.value,
+    gasLimit: log.args.gasLimit,
+    data: log.args.data,
+    withdrawalHash: log.args.withdrawalHash,
+    blockNumber: log.blockNumber,
+  }
+}
+
+type WithdrawalsProps = {
+  publicClientL2: PublicClient
+  explorerURL?: string
+}
+
+const Withdrawals = ({ publicClientL2, explorerURL }: WithdrawalsProps) => {
+  const [withdrawals, setWithdrawals] = useState<Withdrawal[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const logs = await publicClientL2.getLogs({
+          address: L2_CONTRACTS.L2ToL1MessagePasser as Address,
+          event: MESSAGE_PASSED_EVENT,
+          fromBlock: 0n,
+        })
+        const events = logs.map(parseMessagePassedLog)
+        events.reverse()
+        setWithdrawals(events.slice(0, 20))
+      } catch (err) {
+        console.error('Error fetching withdrawals', err)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    load()
+  }, [publicClientL2])
+
+  if (loading) {
+    return <div>Loading withdrawals...</div>
+  }
+
+  if (withdrawals.length === 0) {
+    return <div>No withdrawals found.</div>
+  }
+
+  return (
+    <div>
+      <table className="withdrawal-table">
+        <thead>
+          <tr>
+            <th>Nonce</th>
+            <th>Sender</th>
+            <th>Target</th>
+            <th>Value</th>
+            <th>Gas Limit</th>
+            <th>Hash</th>
+          </tr>
+        </thead>
+        <tbody>
+          {withdrawals.map(w => (
+            <tr key={w.withdrawalHash}>
+              <td>{w.nonce.toString()}</td>
+              <td><DisplayAddress address={w.sender} blockExplorerURL={explorerURL} /></td>
+              <td><DisplayAddress address={w.target} blockExplorerURL={explorerURL} /></td>
+              <td>{w.value.toString()}</td>
+              <td>{w.gasLimit.toString()}</td>
+              <td className="hex">{`${w.withdrawalHash.slice(0,10)}...${w.withdrawalHash.slice(-8)}`}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export default Withdrawals

--- a/src/pages/WithdrawalsPage.tsx
+++ b/src/pages/WithdrawalsPage.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import type { PublicClient } from 'viem'
+import Withdrawals from '../components/Withdrawals'
+
+interface WithdrawalsPageProps {
+  publicClientL2: PublicClient | null
+  explorerURL?: string
+}
+
+const WithdrawalsPage: React.FC<WithdrawalsPageProps> = ({ publicClientL2, explorerURL }) => {
+  if (!publicClientL2) {
+    return <div>Loading client...</div>
+  }
+
+  return (
+    <div>
+      <h1 className="mb-6">Withdrawals</h1>
+      <Withdrawals publicClientL2={publicClientL2} explorerURL={explorerURL} />
+    </div>
+  )
+}
+
+export default WithdrawalsPage


### PR DESCRIPTION
## Summary
- parse the MessagePassed ABI item and use it when querying logs
- verify the event definition in unit tests

## Testing
- `npm test --silent`
